### PR TITLE
Disable `tag_svn_revision` so `pip wheel` doesn't append .r0 & bump version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [egg_info]
 tag_build =
-tag_svn_revision = true
 
 [nosetests]
 verbose=True

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import sys, os
 
-version = '1.1+dd.2'
+version = '1.1+dd.3'
 
 setup(name='openid-redis',
       version=version,


### PR DESCRIPTION
We're using this lib in a couple of different builds and the .r0 is making
things difficult in some of them.