### PR TITLE
Run futurize to make python 3 compatible

### DIFF
--- a/openidredis/__init__.py
+++ b/openidredis/__init__.py
@@ -7,6 +7,7 @@ python-openid FileStore code is Copyright JanRain, under the Apache Software
 License.
 
 """
+from past.builtins import cmp
 import logging
 import string
 import time

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import sys, os
 
-version = '1.1+dd.3'
+version = '1.1+dd.4'
 
 setup(name='openid-redis',
       version=version,
@@ -12,7 +12,9 @@ setup(name='openid-redis',
         "Development Status :: 6 - Mature",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
-        "Topic :: Internet :: WWW/HTTP"
+        "Topic :: Internet :: WWW/HTTP",
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3'
       ],
       keywords='openid redis',
       author='Ben Bangert',

--- a/tests/test_redisstore.py
+++ b/tests/test_redisstore.py
@@ -6,6 +6,7 @@ Copyright JanRain
 Apache Software License
 
 """
+from __future__ import print_function
 
 import unittest
 import string


### PR DESCRIPTION
This forked lib is used in dogweb and needs to be made py3 compatible.